### PR TITLE
Remove extraneous `!` from test commands

### DIFF
--- a/lib/test/test_assert.sh
+++ b/lib/test/test_assert.sh
@@ -17,6 +17,7 @@
 #
 :PREFIX:assert() {
 	if [[ "$1" = "!" ]]; then
+		shift
 		if ! "$@" &>/dev/null; then
 			return 0
 		fi

--- a/lib/test/test_expect.sh
+++ b/lib/test/test_expect.sh
@@ -17,6 +17,7 @@
 #
 :PREFIX:expect() {
 	if [[ "$1" = "!" ]]; then
+		shift
 		if ! "$@" &>/dev/null; then
 			return 0
 		fi


### PR DESCRIPTION
I was running tests in eth-p/best, where I received errors like the following:

```
[FAIL] compare_eq           :: Exited with code 134.
[FAIL] compare_ge           :: Exited with code 134.
[FAIL] compare_gt           :: Exited with code 134.
[FAIL] compare_le           :: Exited with code 134.
[FAIL] compare_lt           :: Exited with code 134.
[FAIL] compare_ne           :: Exited with code 134.
```

I traced the problem back to this repo, and it looks like the command is being executed with the `!` in front of it, which is (I think?) supposed to be syntax for the `expect` function. I am not sure why this was working before, but at least on Bash version 5.2.15, this causes the error above. When the `!` is `shift`ed out of the args, the error goes away and all test pass.